### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default reviewers
+*                 @greenbone/gvmd-maintainers


### PR DESCRIPTION
This sets the gvmd maintainers as the default reviewers.