### PR TITLE
Use dynamic timestamps for iCalendar tests

### DIFF
--- a/tests/next_time_ical.sql
+++ b/tests/next_time_ical.sql
@@ -28,13 +28,17 @@ BEGIN
     -- If 03:07:00 on the 21st has already passed in May / November,
     --  add 6 months.
     IF $2 > next_time THEN
-      next_time = next_time + interval '6 months';
+      next_time 
+        = (next_time AT TIME ZONE 'Europe/Berlin' + interval '6 months')
+            AT TIME ZONE 'Europe/Berlin';
     END IF;
 
     -- Apply offset
-    next_time = next_time + ($1 * interval '6 months');
+    next_time 
+      = (next_time AT TIME ZONE 'Europe/Berlin' + ($1 * interval '6 months'))
+          AT TIME ZONE 'Europe/Berlin';
 
-    RETURN extract (EPOCH FROM next_time AT TIME ZONE 'UTC');
+    RETURN extract (EPOCH FROM (next_time AT TIME ZONE 'UTC'));
 END;
 $$ LANGUAGE plpgsql;
 
@@ -42,25 +46,25 @@ $$ LANGUAGE plpgsql;
 -- Test the date test model function
 --
 
--- 2020-02-02T12:00:00 -> 2020-05-21T03:07:00
+-- 2020-02-02T12:00:00 CET -> 2020-05-21T03:07:00 CEST
 SELECT is (next_test_time (0, to_timestamp (1580641200)), 1590023220);
 
--- 2020-05-21T03:00:00 -> 2020-05-21T03:07:00
+-- 2020-05-21T03:00:00 CEST -> 2020-05-21T03:07:00 CEST
 SELECT is (next_test_time (0, to_timestamp (1590022800)), 1590023220);
 
--- 2020-05-21T03:10:00 -> 2020-11-21T03:07:00
+-- 2020-05-21T03:10:00 CEST -> 2020-11-21T03:07:00 CET
 SELECT is (next_test_time (0, to_timestamp (1590023400)), 1605924420);
 
--- 2020-08-21T00:00:00 -> 2020-11-21T03:07:00
+-- 2020-08-21T00:00:00 CEST -> 2020-11-21T03:07:00 CET
 SELECT is (next_test_time (0, to_timestamp (1597960800)), 1605924420);
 
--- 2020-11-21T03:00:00 -> 2020-11-21T03:07:00
+-- 2020-11-21T03:00:00 CET -> 2020-11-21T03:07:00 CET
 SELECT is (next_test_time (0, to_timestamp (1605924000)), 1605924420);
 
--- 2020-11-21T03:10:00 -> 2021-05-21T03:07:00
+-- 2020-11-21T03:10:00 CET -> 2021-05-21T03:07:00 CEST
 SELECT is (next_test_time (0, to_timestamp (1605924600)), 1621559220);
 
--- 2020-12-12T11:11:11 -> 2021-05-21T03:07:00
+-- 2020-12-12T11:11:11 CET -> 2021-05-21T03:07:00 CEST
 SELECT is (next_test_time (0, to_timestamp (1607767871)), 1621559220);
 
 --

--- a/tests/next_time_ical.sql
+++ b/tests/next_time_ical.sql
@@ -2,9 +2,72 @@
 BEGIN;
 
 -- IMPORTANT! See https://pgtap.org/documentation.html#iloveitwhenaplancomestogether
-SELECT plan(3);
+SELECT plan(10);
 
--- Run the tests.
+-- Function to calculate the test timestamps based on current time
+--  PostgreSQL internal date-time functions.
+CREATE OR REPLACE FUNCTION next_test_time (integer, timestamp with time zone)
+RETURNS integer AS $$
+DECLARE
+    current_year integer;
+    current_month integer;
+    next_time timestamp with time zone;
+BEGIN
+    current_year = EXTRACT (year FROM $2);
+    current_month = EXTRACT (month FROM $2);
+
+    -- First guess based on month
+    IF current_month <= 5 THEN
+      next_time
+        = make_timestamptz(current_year, 5, 21, 3, 7, 0, 'Europe/Berlin');
+    ELSE
+      next_time
+        = make_timestamptz(current_year, 11, 21, 3, 7, 0, 'Europe/Berlin');
+    END IF;
+
+    -- If 03:07:00 on the 21st has already passed in May / November,
+    --  add 6 months.
+    IF $2 > next_time THEN
+      next_time = next_time + interval '6 months';
+    END IF;
+
+    -- Apply offset
+    next_time = next_time + ($1 * interval '6 months');
+
+    RETURN extract (EPOCH FROM next_time AT TIME ZONE 'UTC');
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Test the date test model function
+--
+
+-- 2020-02-02T12:00:00 -> 2020-05-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1580641200)), 1590023220);
+
+-- 2020-05-21T03:00:00 -> 2020-05-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1590022800)), 1590023220);
+
+-- 2020-05-21T03:10:00 -> 2020-11-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1590023400)), 1605924420);
+
+-- 2020-08-21T00:00:00 -> 2020-11-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1597960800)), 1605924420);
+
+-- 2020-11-21T03:00:00 -> 2020-11-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1605924000)), 1605924420);
+
+-- 2020-11-21T03:10:00 -> 2021-05-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1605924600)), 1621559220);
+
+-- 2020-12-12T11:11:11 -> 2021-05-21T03:07:00
+SELECT is (next_test_time (0, to_timestamp (1607767871)), 1621559220);
+
+--
+-- Run the tests for the actual iCalendar function.
+--
+
+-- Test without offset parameter
 SELECT is (next_time_ical('BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 
@@ -35,8 +98,11 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin'), 1605924420, 'Calculation was wrong');
+END:VCALENDAR', 'Europe/Berlin'),
+next_test_time (0, now ()),
+'Calculation was wrong');
 
+-- Test with offset parameter set to 0
 SELECT is (next_time_ical('BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 
@@ -67,8 +133,11 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin', 0), 1605924420, 'Calculation was wrong');
+END:VCALENDAR', 'Europe/Berlin', 0),
+next_test_time (0, now ()),
+'Calculation was wrong');
 
+-- Test with offset parameter set to -1
 SELECT is (next_time_ical('BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 
@@ -99,8 +168,13 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin', -1), 1590023220, 'Calculation was wrong');
+END:VCALENDAR', 'Europe/Berlin', -1),
+next_test_time (-1, now ()),
+'Calculation was wrong');
 
 -- Finish the tests and clean up.
 SELECT * FROM finish();
+
+DROP FUNCTION next_test_time (integer, timestamp with time zone);
+
 ROLLBACK;


### PR DESCRIPTION
*What was done?*
The tests for next_time_ical now use timestamps generated by built-in
date-time functions and this test model is tested with fixed dates
instead.

*Why?*
This is needed because the expected results depend on the current
date and time.

*How was it tested?*
By running the tests and checking intermediate results manually.