### PR TITLE
Add option to use an installation prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,11 @@ jobs:
           name: Add "/usr/local/lib" as ld directory
           command: echo "/usr/local/lib" >> /etc/ld.so.conf.d/gvm.conf && ldconfig
       - run:
+          name: Create symlinks for extension to install prefix
+          command: /usr/local/sbin/pg-gvm-make-dev-links
+      - run:
           name: Add pg-gvm extension
-          command: su postgres -c "psql -d gvmd -c 'CREATE EXTENSION \"pg-gvm\";'"
+          command: psql -d gvmd -c 'SET ROLE dba; CREATE EXTENSION "pg-gvm";'
       - run:
           name: Create gvmd tables
           command: psql -d gvmd < gvmd-tables.sql

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,19 @@ add_custom_command(
     DEPENDS ${SQL})
 
 # Define install targets
-install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION "${PostgreSQL_EXTLIB_DIR}")
-install(FILES "${CMAKE_BINARY_DIR}/${CONTROLOUT}" DESTINATION "${PostgreSQL_SHARE_DIR}/extension")
-install(FILES "${CMAKE_BINARY_DIR}/${SQLOUT}" DESTINATION "${PostgreSQL_SHARE_DIR}/extension")
+if (CMAKE_INSTALL_PREFIX)
+  install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/postgresql")
+  configure_file("${CMAKE_SOURCE_DIR}/pg-gvm-make-dev-links.in" "${CMAKE_BINARY_DIR}/pg-gvm-make-dev-links" @ONLY)
+  install(
+    FILES "${CMAKE_BINARY_DIR}/pg-gvm-make-dev-links"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/sbin"
+    PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+  install(FILES "${CMAKE_BINARY_DIR}/${CONTROLOUT}" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/postgresql/extension")
+  install(FILES "${CMAKE_BINARY_DIR}/${SQLOUT}" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/postgresql/extension")
+  message(NOTICE "${CMAKE_PROJECT_NAME} installed with prefix. Run ${CMAKE_INSTALL_PREFIX}/sbin/pg-gvm-make-dev-links as root to create symlinks to this installation.")
+else (CMAKE_INSTALL_PREFIX)
+  install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION "${PostgreSQL_EXTLIB_DIR}")
+  install(FILES "${CMAKE_BINARY_DIR}/${CONTROLOUT}" DESTINATION "${PostgreSQL_SHARE_DIR}/extension")
+  install(FILES "${CMAKE_BINARY_DIR}/${SQLOUT}" DESTINATION "${PostgreSQL_SHARE_DIR}/extension")
+endif (CMAKE_INSTALL_PREFIX)

--- a/pg-gvm-make-dev-links.in
+++ b/pg-gvm-make-dev-links.in
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# Helper script to create symlinks for development setups of pg-gvm
+#
+
+PREFIX_SHARE_DIR="@CMAKE_INSTALL_PREFIX@/share/postgresql"
+PREFIX_EXTLIB_DIR="@CMAKE_INSTALL_PREFIX@/lib/postgresql"
+
+REAL_SHARE_DIR="@PostgreSQL_SHARE_DIR@"
+REAL_EXTLIB_DIR="@PostgreSQL_EXTLIB_DIR@"
+
+LIB_PREFIX="@CMAKE_SHARED_MODULE_PREFIX@"
+LIB_SUFFIX="@CMAKE_SHARED_MODULE_SUFFIX@"
+LIB_FILE_NAME="${LIB_PREFIX}@CMAKE_PROJECT_NAME@${LIB_SUFFIX}"
+
+CONTROLOUT="@CONTROLOUT@"
+SQLOUT="@SQLOUT@"
+
+echo "Creating links:"
+
+echo "  $REAL_SHARE_DIR/extension/$CONTROLOUT"
+ln -s "$PREFIX_SHARE_DIR/extension/$CONTROLOUT" \
+   "$REAL_SHARE_DIR/extension/$CONTROLOUT"
+
+echo "  $REAL_SHARE_DIR/extension/$SQLOUT"
+ln -s "$PREFIX_SHARE_DIR/extension/$SQLOUT" \
+   "$REAL_SHARE_DIR/extension/$SQLOUT"
+
+echo "  $REAL_EXTLIB_DIR/$LIB_FILE_NAME"
+ln -s "$PREFIX_EXTLIB_DIR/$LIB_FILE_NAME" \
+   "$REAL_EXTLIB_DIR/$LIB_FILE_NAME"


### PR DESCRIPTION
If CMAKE_INSTALL_PREFIX is defined and not empty, the extension will be
installed there instead of the paths from pgconfig.

Also, a helper script is added to create symlinks in the pgconfig
directories to the files in the prefix directories so development
setups can install new versions of pg-gvm without root permissions.