### PR TITLE
Fix next_time_ical and add reference_time param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required(VERSION 3.0)
 message ("-- Configuring PostgreSQL extension for GVMd functions...")
 
 project(pg-gvm
-        VERSION 1.0
+        VERSION 1.1
         LANGUAGES C)
 
 # List all sourcefiles

--- a/control.in
+++ b/control.in
@@ -1,3 +1,3 @@
 comment = 'Functions for GVMd'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/libLIBNAME'

--- a/include/ical_utils.h
+++ b/include/ical_utils.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Greenbone Networks GmbH
+/* Copyright (C) 2020-2022 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
@@ -31,10 +31,11 @@ icaltimezone *
 icalendar_timezone_from_string_x (const char *);
 
 time_t
-icalendar_next_time_from_string_x (const char *, const char *, int);
+icalendar_next_time_from_string_x (const char *, time_t, const char *, int);
 
 time_t
-icalendar_next_time_from_vcalendar_x (icalcomponent *, const char *, int);
+icalendar_next_time_from_vcalendar_x (icalcomponent *, time_t, const char *,
+                                      int);
 
 #endif
 

--- a/pg-gvm-make-dev-links.in
+++ b/pg-gvm-make-dev-links.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2021 Greenbone Networks GmbH
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/sql/ical.in.sql
+++ b/sql/ical.in.sql
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Greenbone Networks GmbH
+/* Copyright (C) 2020-2022 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
@@ -16,12 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-CREATE OR REPLACE FUNCTION next_time_ical (text, text)
+CREATE OR REPLACE FUNCTION next_time_ical (text, bigint, text)
     RETURNS integer
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$sql_next_time_ical$$;
 
-CREATE OR REPLACE FUNCTION next_time_ical (text, text, integer)
+CREATE OR REPLACE FUNCTION next_time_ical (text, bigint, text, integer)
     RETURNS integer
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$sql_next_time_ical$$;
+
+DROP FUNCTION IF EXISTS next_time_ical (text, text);
+
+DROP FUNCTION IF EXISTS  next_time_ical (text, text, integer);

--- a/src/ical.c
+++ b/src/ical.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Greenbone Networks GmbH
+/* Copyright (C) 2020-2022 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
@@ -67,6 +67,7 @@ Datum
 sql_next_time_ical (PG_FUNCTION_ARGS)
 {
   char *ical_string, *zone;
+  int64 reference_time;
   int periods_offset;
   int32 ret;
 
@@ -83,20 +84,25 @@ sql_next_time_ical (PG_FUNCTION_ARGS)
     }
 
   if (PG_NARGS() < 2 || PG_ARGISNULL (1))
+    reference_time = 0;
+  else
+    reference_time = PG_GETARG_INT64 (1);
+    
+  if (PG_NARGS() < 3 || PG_ARGISNULL (2))
     zone = NULL;
   else
     {
       text* timezone_arg;
-      timezone_arg = PG_GETARG_TEXT_P (1);
+      timezone_arg = PG_GETARG_TEXT_P (2);
       zone = textndup (timezone_arg, VARSIZE (timezone_arg) - VARHDRSZ);
     }
 
-  if (PG_NARGS() < 3)
+  if (PG_NARGS() < 4)
     periods_offset = 0;
   else
-    periods_offset = PG_GETARG_INT32 (2);
+    periods_offset = PG_GETARG_INT32 (3);
 
-  ret = icalendar_next_time_from_string_x (ical_string, zone,
+  ret = icalendar_next_time_from_string_x (ical_string, reference_time, zone,
                                            periods_offset);
   if (ical_string)
     pfree (ical_string);

--- a/tests/next_time_ical.sql
+++ b/tests/next_time_ical.sql
@@ -102,7 +102,7 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin'),
+END:VCALENDAR', EXTRACT (EPOCH from now())::bigint, 'Europe/Berlin'),
 next_test_time (0, now ()),
 'Calculation was wrong');
 
@@ -137,7 +137,7 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin', 0),
+END:VCALENDAR', EXTRACT (EPOCH from now())::bigint, 'Europe/Berlin', 0),
 next_test_time (0, now ()),
 'Calculation was wrong');
 
@@ -172,7 +172,7 @@ RRULE:FREQ=MONTHLY;INTERVAL=6;BYMONTHDAY=21
 UID:8c022087-e10a-462e-a1af-65559601a0db
 DTSTAMP:20200615T161125Z
 END:VEVENT
-END:VCALENDAR', 'Europe/Berlin', -1),
+END:VCALENDAR', EXTRACT (EPOCH from now())::bigint, 'Europe/Berlin', -1),
 next_test_time (-1, now ()),
 'Calculation was wrong');
 


### PR DESCRIPTION
**What**:
The next_time_ical function now has a new parameter for the
reference time, which should be the current time.
The function now no longer returns the current/reference time as the
next time when it is the same as a recurrence time.

**Why**:
This allows using a consistent reference time throughout queries that
take a longer time to run.
The recurrence time issue could cause unwanted effects like scheduled
tasks being started twice for the same scheduled time. (AP-1991)

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
