### PR TITLE
Build pg-gvm postgres image that fits for gvmd stable

### DIFF
--- a/.docker/stable.Dockerfile
+++ b/.docker/stable.Dockerfile
@@ -1,0 +1,38 @@
+ARG VERSION=stable
+
+FROM greenbone/gvmd:${VERSION} as gvmd
+FROM greenbone/gvm-libs:${VERSION}
+
+COPY --from=gvmd /usr/local/lib/libgvm-pg-server.so /usr/local/lib/
+COPY .docker/start-postgresql.sh /usr/local/bin/start-postgresql
+COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
+
+RUN chmod 755 /usr/local/bin/start-postgresql /usr/local/bin/entrypoint
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gosu \
+    libgpgme11 \
+    libical3 \
+    libpq5 \
+    postgresql-13 \
+    postgresql-client-13 \
+    postgresql-client-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ldconfig
+
+WORKDIR /home/postgres
+
+RUN usermod -u 104 postgres && groupmod -g 106 postgres
+
+RUN chown -R postgres:postgres /var/lib/postgresql
+RUN chown -R postgres:postgres /var/run/postgresql
+RUN chown -R postgres:postgres /var/log/postgresql
+RUN chown -R postgres:postgres /etc/postgresql
+
+RUN sed -i 's/peer/trust/' /etc/postgresql/13/main/pg_hba.conf
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
+
+CMD ["/usr/local/bin/start-postgresql"]

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,13 +22,28 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push Container image
+      - name: Build and push unstable Container image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: ${{ steps.container.outputs.image-tags }}
           file: .docker/prod.Dockerfile
+          labels: |
+            org.opencontainers.image.vendor=Greenbone
+            org.opencontainers.image.revision=${{ github.sha }}
+      # for the current stable release pg-gvm is contained in gvmd
+      # after the next release getting stable this must be changed to oldstable
+      - name: Build and push stable Container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: greenbone/pg-gvm:stable
+          file: .docker/stable.Dockerfile
+          labels: |
+            org.opencontainers.image.vendor=Greenbone
+            org.opencontainers.image.revision=${{ github.sha }}
 
   upload-build:
     name: "Upload images for building pg-gvm"


### PR DESCRIPTION
**What**:

Build pg-gvm postgres image that fits for gvmd stable

**Why**:

With gvmd stable (21.04) the postgres pg-gvm library is build with gvmd
and is not separated in this repository. But the container image for
running postgres requires this library to be installed. Therefore build
a special pg-gvm image for the current stable release.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
