### PR TITLE
fix missing gosu

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
     libgpgme11 \
     libical3 \
     libpq5 \
+    gosu \
     postgresql-13 \
     postgresql-client-13 \
     postgresql-client-common && \


### PR DESCRIPTION
**What**:

gosu was added to the `prod.Dockerfile` as dependency

**Why**:

gosu was missing but s required by the `entrypoint.sh` script added with #23 

**How**:

* building container in old state
* executing with [greenbone-docker/unstable](https://github.com/greenbone/greenbone-docker/blob/main/docker-compose/unstable.yml) results in errors in the log:
* `/usr/local/bin/entrypoint: 21: exec: gosu: not found`
* adding gosu and building container again
* executeing with `unstable.yml` does not result in errors (when `drop_caps: ALL` is removed)

**Checklist**:

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
