### PR TITLE
fix: make /var/lib/postgresql/started accessible

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -22,7 +22,7 @@ chown -R postgres:postgres /var/lib/postgresql
 chown -R postgres:postgres /var/run/postgresql
 chown -R postgres:postgres /var/log/postgresql
 chown -R postgres:postgres /etc/postgresql
-chmod 0750 /var/lib/postgresql
+chmod 0755 /var/lib/postgresql
 chmod 0750 /var/lib/postgresql/13/main || true
 
 exec gosu postgres "$@"


### PR DESCRIPTION
**What**:

make the `/var/lib/postgresql/started` accessible again for gvmd

**Why**:

[Comment](https://github.com/greenbone/pg-gvm/pull/32#issuecomment-1186003016)

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
