### PR TITLE
Raise libgvm_base version requirements to 22.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include (FindPkgConfig)
 # Check if libical is installed
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=20.8)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
 
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
**What**:
The version for the base GVM library requirement is raised to 22.4

**Why**:
To ensure the current version is used to build the extension.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
