### PR TITLE
Fix: Support PostgeSQL 14 and 15 out of the box

### DIFF
--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Install build dependencies:
+    - name: Install build dependencies
       run: .github/workflows/install-build-dependencies.sh
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -87,7 +87,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-    "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES


### PR DESCRIPTION
## What

Support PostgeSQL 14 and 15 out of the box

## Why

Extend the `FindPostgreSQL.cmake` file to look for PostgreSQL 14 and 15 too. 15 is the latest release and now included in all major distributions. 14 is used in the Ubuntu 22.04 LTS version.
