### PR TITLE
Change: Use oldstable for release Docker images

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,6 +1,6 @@
-ARG VERSION=oldstable
+ARG GVM_LIBS_VERSION=oldstable
 
-FROM greenbone/gvm-libs:${VERSION} as builder
+FROM greenbone/gvm-libs:${GVM_LIBS_VERSION} as builder
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
@@ -29,7 +29,7 @@ RUN mkdir /build && \
     cmake -DCMAKE_BUILD_TYPE=Release /source && \
     make DESTDIR=/install install
 
-FROM greenbone/gvm-libs:${VERSION}
+FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
 
 COPY --from=builder /install/ /
 COPY .docker/start-postgresql.sh /usr/local/bin/start-postgresql

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,6 +45,14 @@ jobs:
             # when a new git tag is created set stable and a latest tags
             type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
             type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+      - name: Set container build options
+        id: container-opts
+        run: |
+          if [[ "${{ github.ref_type }}" = 'tag' ]]; then
+            echo "gvm-libs-version=oldstable" >> $GITHUB_OUTPUT
+          else
+            echo "gvm-libs-version=oldstable-edge" >> $GITHUB_OUTPUT
+          fi
       - name: Login to Docker Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -60,6 +68,8 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'main') }}
+          build-args: |
+            GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
           file: .docker/prod.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## What
When building Docker images for release tags, use the oldstable gvm-libs image, otherwise use oldstable-edge.


## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


