### PR TITLE
Change: Raise required gvm-libs version to 22.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include (FindPkgConfig)
 # Check if libical is installed
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.6)
 
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
## What
Raise required gvm-libs version to 22.6

## Why

pg-gvm doesn't build with an older version.