### PR TITLE
Add conventional commits check workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,16 @@
+name: Conventional Commits
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report Conventional Commits
+        uses: greenbone/actions/conventional-commits@v2


### PR DESCRIPTION
## What

Add conventional commits check workflow

## Why

Add a workflow to add a PR comment about used conventional commits.