### PR TITLE
Fix: Add missing migration from pg-gvm 22.5 to 22.6

### DIFF
--- a/sql/update/pg-gvm--22.5--22.6.sql
+++ b/sql/update/pg-gvm--22.5--22.6.sql
@@ -1,0 +1,7 @@
+/* SPDX-FileCopyrightText: 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+-- Empty update. Nothing has changed.


### PR DESCRIPTION


## What

Add missing migration from pg-gvm 22.5 to 22.6

## Why

A sql update file is required for each minor and major release.

## References

https://forum.greenbone.net/t/extension-pg-gvm-has-no-update-path/15299
https://forum.greenbone.net/t/docker-container-update-gvmd-broken/15297

GEA-270

