### PR TITLE
Fix: Fix creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Selecting the Release type
         id: release-type
         uses: greenbone/actions/release-type@v3


### PR DESCRIPTION


## What

Fix creating a release
## Why

When changes should be pushed to the repo the original checkout must be done without persisting the credentials. Otherwise we can't override the permissions later and use our bot for pushing the changes to the repository.

