### PR TITLE
Add: Push to self-hosted registry workflow for image

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,27 @@
+name: Build and Push to Greenbone Registry
+
+on:
+  push:
+    branches: [ main ]
+    tags: ["v*"]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      ref-name:
+        type: string
+        description: "The ref to build a container image from. For example a tag v23.0.0."
+        required: true
+
+jobs:
+  push:
+    name: Build and push to self-hosted harbor
+    uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
+    with:
+      image-labels: |
+        org.opencontainers.image.vendor=Greenbone
+        org.opencontainers.image.documentation=https://greenbone.github.io/docs/
+        org.opencontainers.image.base.name=debian:stable-slim
+      image-url: community/greenbone-feed-sync
+      ref-name: ${{ inputs.ref-name }}
+    secrets: inherit


### PR DESCRIPTION
## What

image to self-hosted registry

## Why

need to be uploaded to the new registry, too!

## References

[DEVOPS-1191](https://jira.greenbone.net/browse/DEVOPS-1191)