### PR TITLE
Improve Release Changelog Generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,29 @@
+name: Show changelog since last release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    name: Show changelog since last release
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for conventional commits and getting all git tags
+          persist-credentials: false
+      - name: Install git-cliff
+        uses: greenbone/actions/uv@v3
+        with:
+          install: git-cliff
+      - name: Determine changelog
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git-cliff -v --strip header --unreleased -o /tmp/changelog.md
+      - name: Show changelog
+        run: |
+          cat /tmp/changelog.md
+          cat /tmp/changelog.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       release-type:
         type: choice
-        description: What kind of release do you want to do (pontos --release-type argument)?
+        description: What kind of release do you want to do?
         options:
           - patch
           - minor
@@ -22,8 +22,8 @@ jobs:
     # If the event is a workflow_dispatch or on of the labels 'pre release',
     # 'patch release', 'minor release' or 'major release' is set and PR is
     # closed because of a merge
-    # NOTE: priority of set labes will be alpha > release-candidate > patch > minor > major,
-    #       so if 'major' and 'patch' labes are set, it will create a patch release.
+    # NOTE: priority of set labels will be alpha > release-candidate > patch > minor > major,
+    #       so if 'major' and 'patch' labels are set, it will create a patch release.
     if: |
       ( github.event_name == 'workflow_dispatch') || (
         ( contains(github.event.pull_request.labels.*.name, 'alpha release') ||
@@ -32,36 +32,49 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'minor release') ||
           contains(github.event.pull_request.labels.*.name, 'major release')) &&
           github.event.pull_request.merged == true )
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
       - name: Selecting the Release type
         id: release-type
         uses: greenbone/actions/release-type@v3
         with:
           release-type-input: ${{ inputs.release-type }}
-      - name: Install pontos
-        uses: greenbone/actions/setup-pontos@v3
-      - name: Release Version
-        id: release
-        run:
-          pontos-release show --release-type ${{ steps.release-type.outputs.release-type }} --output-format github-action
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for conventional commits and getting all git tags
+          persist-credentials: false
+          ref: ${{ steps.release-type.outputs.release-ref }}
+      - name: Determine release version
+        id: release-version
+        uses: greenbone/actions/release-version@v3
+        with:
+          release-type: ${{ steps.release-type.outputs.release-type }}
+          release-version: ${{ inputs.release-version }}
+          versioning-scheme: "semver"
       - name: Show versions
         run: |
-          echo "Current release: ${{ steps.release.outputs.last_release_version}}"
-          echo "Next release: ${{ steps.release.outputs.release_version}}"
+          echo "Current release: ${{ steps.release-version.outputs.last-release-version}}"
+          echo "Next release: ${{ steps.release-version.outputs.release-version}}"
       - name: Check for SQL migration script
         run: |
-          found=$(find ./sql/update -name "*--${{ steps.release.outputs.release_version_major }}.${{ steps.release.outputs.release_version_minor }}.sql" | wc -l)
+          found=$(find ./sql/update -name "*--${{ steps.release-version.outputs.release-version-major }}.${{ steps.release-version.outputs.release-version-minor }}.sql" | wc -l)
           if [ $found -eq 0 ]; then
-            echo "::error ::Missing SQL migration file in ./sql/update for ${{ steps.release.outputs.release_version_major }}.${{ steps.release.outputs.release_version_minor }} release"
+            echo "::error ::Missing SQL migration file in ./sql/update for ${{ steps.release-version.outputs.release-version-major }}.${{ steps.release-version.outputs.release-version-minor }} release"
             exit 1
           fi
+      - name: Install git-cliff
+        uses: greenbone/actions/uv@v3
+        with:
+          install: git-cliff
+      - name: Determine changelog
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git-cliff -v --strip header -o /tmp/changelog.md --unreleased --tag ${{ steps.release-version.outputs.release-version }} ${{ steps.release-version.outputs.last-release-version }}..HEAD
       - name: Release with release action
+        id: release
         uses: greenbone/actions/release@v3
         with:
           github-user: ${{ secrets.GREENBONE_BOT }}
@@ -70,7 +83,7 @@ jobs:
           gpg-key: ${{ secrets.GPG_KEY }}
           gpg-fingerprint: ${{ secrets.GPG_FINGERPRINT }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          release-type: ${{ steps.release-type.outputs.release-type }}
-          release-version: ${{ inputs.release-version }}
+          release-version: ${{ steps.release-version.outputs.release-version }}
+          changelog: /tmp/changelog.md
           ref: ${{ steps.release-type.outputs.release-ref }}
           versioning-scheme: "semver"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+[changelog]
+# template for the changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+            {% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){%- endif -%}
+            {% if commit.remote.pr_number %} in \
+            [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}) \
+            {% elif commit.id %} in \
+            [{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }})\
+            {%- endif -%}
+    {% endfor %}
+{% endfor -%}
+"""
+# template for the changelog footer
+footer = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% for release in releases %}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                {{ self::remote_url() }}/compare/{{ release.previous.version }}..{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: {{ self::remote_url() }}/compare/{{ release.previous.version }}..HEAD
+    {% endif -%}
+{%- endfor -%}
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not following the conventional commits format
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  # remove issue numbers from commits
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^[a|A]dd", group = "<!-- 1 -->:sparkles: Added" },
+  { message = "^[c|C]hange", group = "<!-- 2 -->:construction_worker: Changed" },
+  { message = "^[f|F]ix", group = "<!-- 3 -->:bug: Bug Fixes" },
+  { message = "^[r|R]emove", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]rop", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]oc", group = "<!-- 5 -->:books: Documentation" },
+  { message = "^[t|T]est", group = "<!-- 6 -->:white_check_mark: Testing" },
+  { message = "^[c|C]hore", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[c|C]i", group = "<!-- 7 -->️:wrench: Miscellaneous" },
+  { message = "^[m|M]isc", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[d|D]eps", group = "<!-- 8 -->:ship: Dependencies" },
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION


## What

Improve Release Changelog Generation
## Why

Add a new CI workflow for showing the latest changelog independent of a release. Use git-cliff to generate a more flexible and improved release changelog.

## References

https://jira.greenbone.net/browse/GEA-984


