### PR TITLE
Fix building the migrator container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,10 +49,11 @@ jobs:
     with:
       ref: ${{ inputs.ref-name }}
       ref-name: ${{ inputs.ref-name }}
+      name: migrator
       dockerfile: ./.docker/migrator.Dockerfile
       images: |
         ghcr.io/${{ github.repository }}-migrator,enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }}-migrator,enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }}-migrator,enable=${{ github.event_name != 'pull_request' }}
     secrets: inherit
 
   notify:


### PR DESCRIPTION


## What

Fix building the migrator container image

## Why

Specify a name for the migrator build job because that name is used for the digest file that is used for creating the tagged multi arch image. Without specifying the name for the migrator both jobs use the same digest file and the wrong images get tagged.