### PR TITLE
Fix migrator image build by setting a dedicated main-image name

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,6 +50,7 @@ jobs:
       ref: ${{ inputs.ref-name }}
       ref-name: ${{ inputs.ref-name }}
       name: migrator
+      main-image: ghcr.io/${{ github.repository }}-migrator
       dockerfile: ./.docker/migrator.Dockerfile
       images: |
         ghcr.io/${{ github.repository }}-migrator,enable=true


### PR DESCRIPTION


## What

Fix migrator image build by setting a dedicated main-image name

## Why

The main-image name defaults to `ghcr.io/${{ github.repository }}` and therefore was the same for both image build jobs.


