### PR TITLE
Fix pg-gvm container shutdown

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -34,6 +34,10 @@ RUN usermod -u 104 postgres && groupmod -g 106 postgres && \
     chown -R postgres:postgres /etc/postgresql && \
     chmod 755 /usr/local/bin/start-postgresql /usr/local/bin/entrypoint
 
+# Use fast shutdown mode
+# See https://www.postgresql.org/docs/current/server-shutdown.html
+STOPSIGNAL SIGINT
+
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
 CMD ["/usr/local/bin/start-postgresql"]

--- a/.docker/start-postgresql.sh
+++ b/.docker/start-postgresql.sh
@@ -125,6 +125,12 @@ ensure_extension() {
   [ -n "${EXISTS}" ] || psql_sock -d "${POSTGRES_DB}" -c "CREATE EXTENSION \"${ext}\";"
 }
 
+cleanup() {
+  rm -f "${POSTGRES_DATA}/started"
+  # in case of unclean shutdowns remove the lock file
+  rm -f "${POSTGRES_SOCKET_DIR}/.s.PGSQL.5432.lock"
+}
+
 ensure_extension "uuid-ossp"
 ensure_extension "pgcrypto"
 ensure_extension "pg-gvm"
@@ -132,7 +138,7 @@ ensure_extension "pg-gvm"
 pg_ctlcluster "${POSTGRES_VERSION}" "${POSTGRES_CLUSTER}" stop
 
 touch "${POSTGRES_DATA}/started"
-trap 'rm -f "${POSTGRES_DATA}/started"' EXIT
+trap cleanup EXIT
 
 exec pg_ctlcluster \
   -o "-k ${POSTGRES_SOCKET_DIR}" \


### PR DESCRIPTION

## What

Fix pg-gvm container shutdown

## Why

When the docker daemon is stopped due to for example a restart the container image doesn't get the normal shutdown time. Therefore the postgres database couldn't stop successfully and a dangling lock file `/var/run/postgresql/.s.PGSQL.5432.lock` was kept. The existence of the lock file prevented the start of the database on the next container startup.

To avoid this situation use the [fast shutdown mode](https://www.postgresql.org/docs/current/server-shutdown.html) for postgres and as additional prevention try to remove the lockfile when our startup scripts exits.

## References

https://forum.greenbone.net/t/uncontrolled-shutdown-of-the-postgresql-container/22060
