### PR TITLE
Add health check to pg-gvm container image

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -40,4 +40,6 @@ STOPSIGNAL SIGINT
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
+HEALTHCHECK --interval=5s --retries=3 --timeout=30s --start-period=240s CMD ["pg_isready", "-U", "gvmd", "-d", "gvmd"]
+
 CMD ["/usr/local/bin/start-postgresql"]


### PR DESCRIPTION


## What

Add health check to pg-gvm container image

## Why

Allow to check the health of the pg-gvm container. If the gvmd db is ready the container is healthy.


