### PR TITLE
Update dependabot config and pin actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,11 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*"
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    commit-message:
+      prefix: "Deps"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   changelog:
     name: Show changelog since last release
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false
       - name: Install git-cliff
-        uses: greenbone/actions/uv@v3.36.12
+        uses: greenbone/actions/uv@v3
         with:
           install: git-cliff
       - name: Determine changelog

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -20,7 +20,7 @@ jobs:
     container: registry.community.greenbone.net/community/gvm-libs:${{ matrix.base.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Set up database
@@ -53,8 +53,8 @@ jobs:
     name: Check CMake Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
-      - uses: greenbone/actions/uv@v3.36.12
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: greenbone/actions/uv@v3
         with:
           install: gersemi
       - name: Check CMake Format

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
         # build between init and analyze ...
@@ -44,4 +44,4 @@ jobs:
           cmake --build build -j $(nproc) -- install
         working-directory: ${{ github.WORKSPACE }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: self-hosted-generic
     steps:
       - name: Ensure all tags are replicated on the public registry
-        uses: greenbone/actions/trigger-harbor-replication@v3.36.12
+        uses: greenbone/actions/trigger-harbor-replication@v3
         if: ${{ github.event_name != 'pull_request' }}
         with:
           registry: ${{ vars.GREENBONE_REGISTRY }}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report Conventional Commits
-        uses: greenbone/actions/conventional-commits@v3.36.12
+        uses: greenbone/actions/conventional-commits@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,4 @@
-name: 'Dependency Review'
+name: "Dependency Review"
 on: [pull_request]
 
 permissions:
@@ -8,5 +8,5 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Dependency Review'
-        uses: greenbone/actions/dependency-review@v3.36.12
+      - name: "Dependency Review"
+        uses: greenbone/actions/dependency-review@v3

--- a/.github/workflows/detect-hidden-unicode.yml
+++ b/.github/workflows/detect-hidden-unicode.yml
@@ -7,6 +7,6 @@ jobs:
   detect-hidden-unicode:
     runs-on: ubuntu-latest
     steps:
-      - uses: greenbone/actions/detect-hidden-unicode@v3.36.12
+      - uses: greenbone/actions/detect-hidden-unicode@v3
         with:
           github-token: ${{ secrets.GREENBONE_BOT_TOKEN }}

--- a/.github/workflows/package-build-on-release.yml
+++ b/.github/workflows/package-build-on-release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "release target_commitish: ${{ github.event.release.target_commitish }}"
 
       - name: Trigger development-packaging workflow
-        uses: greenbone/actions/trigger-workflow@v3.36.12
+        uses: greenbone/actions/trigger-workflow@v3
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: "greenbone/gea-pipeline"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,18 @@ jobs:
     steps:
       - name: Selecting the Release type
         id: release-type
-        uses: greenbone/actions/release-type@v3.36.12
+        uses: greenbone/actions/release-type@v3
         with:
           release-type-input: ${{ inputs.release-type }}
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false
           ref: ${{ steps.release-type.outputs.release-ref }}
       - name: Determine release version
         id: release-version
-        uses: greenbone/actions/release-version@v3.36.12
+        uses: greenbone/actions/release-version@v3
         with:
           release-type: ${{ steps.release-type.outputs.release-type }}
           release-version: ${{ inputs.release-version }}
@@ -64,7 +64,7 @@ jobs:
             exit 1
           fi
       - name: Install git-cliff
-        uses: greenbone/actions/uv@v3.36.12
+        uses: greenbone/actions/uv@v3
         with:
           install: git-cliff
       - name: Determine changelog
@@ -75,7 +75,7 @@ jobs:
           git-cliff -v --strip header -o /tmp/changelog.md --unreleased --tag ${{ steps.release-version.outputs.release-version }} ${{ steps.release-version.outputs.last-release-version }}..HEAD
       - name: Release with release action
         id: release
-        uses: greenbone/actions/release@v3.36.12
+        uses: greenbone/actions/release@v3
         with:
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -10,5 +10,5 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: 'SBOM upload'
-        uses: greenbone/actions/sbom-upload@v3.36.12
+      - name: "SBOM upload"
+        uses: greenbone/actions/sbom-upload@v3


### PR DESCRIPTION


## What

Update dependabot config and pin actions to commits

## Why

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews.

Pin actions to commits for improved security. Git tags can be overridden easily. Hashes not.
