### PR TITLE
Fix running the build and test job

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -17,7 +17,7 @@ jobs:
             postgresql: 17
     name: Build and test
     runs-on: ubuntu-latest
-    container: registry.community.greenbone.net/community/gvm-libs:${{ matrix.base.version }}
+    container: ghcr.io/greenbone/gvm-libs:${{ matrix.base.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION


## What

Fix running the build and test job

## Why

The oldstable image is not available on the community registry anymore. Therefore pull the image from the GitHub Container registry.
